### PR TITLE
Update server array definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-local-config.php

--- a/modules/memcache/manifests/init.pp
+++ b/modules/memcache/manifests/init.pp
@@ -20,9 +20,4 @@ class memcache (
     require => Package['memcached'],
     notify  => Service["${php_package}-fpm"]
   }
-
-  file { "${path}/local-config.php":
-    ensure  => file,
-    content => template('memcache/local-config.php.erb'),
-  }
 }

--- a/modules/memcache/templates/local-config.php.erb
+++ b/modules/memcache/templates/local-config.php.erb
@@ -1,5 +1,0 @@
-<?php
-
-// This is generated automatically by Puppet. Edit at your own risk.
-
-$memcached_servers = array( array( '127.0.0.1', 11211 ) );

--- a/modules/memcache/templates/local-config.php.erb
+++ b/modules/memcache/templates/local-config.php.erb
@@ -2,4 +2,4 @@
 
 // This is generated automatically by Puppet. Edit at your own risk.
 
-$memcached_servers = array( '127.0.0.1:11211' );
+$memcached_servers = array( array( '127.0.0.1', 11211 ) );


### PR DESCRIPTION
For some reason the current format doesn't work for me anymore, just hit this today setting up a new project:

`Warning: Memcached::addServers(): server list entry #1 is not an array`

The updated code references the array format defined in http://php.net/manual/en/memcached.addservers.php#example-5263.