### PR TITLE
Remove the local-config.php file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+local-config.php

--- a/local-config.php
+++ b/local-config.php
@@ -1,5 +1,0 @@
-<?php
-
-// This is generated automatically by Puppet. Edit at your own risk.
-
-$memcached_servers = array( '127.0.0.1:11211' );


### PR DESCRIPTION
It looks like this file was accidentally checked in here in https://github.com/Chassis/memcache/pull/16. This config file should be empty so that the default can be picked up when using Memcached, which expects server definition in the form of an array, ie

    $memcached_servers = [ [ '127.0.0.1', 11211 ] ];

Removing this file from version control <strike>will prevent breakage in any setups currently using it, and</strike> ensure that in new Chassis memcache installs the default values set by memcache/memcached will be used. _Actually, hmm: this *might* break Chassis installs that are using the local-config.php previously installed by older versions of the extension. I'm open to thoughts on how to remedy that._