### PR TITLE
Ignore the local-config.php file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+local-config.php


### PR DESCRIPTION
It looks like this file was accidentally checked in here in #16. This
config file should be empty so that the default can be picked up when
using Memcached, which expects server definition in the form of an
array, ie

    $memcached_servers = [ [ '127.0.0.1', 11211 ] ];

Removing this file from version control, while note deleting it, will
prevent breakage in any setups currently using it, and ensure that in
new Chassis memcache installs the default values set by
memcache/memcached will be used.

Closes #25 (solves the problem without breaking existing installs).